### PR TITLE
Category screen: implement subcategory UI and fix API path & image rendering

### DIFF
--- a/frontend/app/src/main/java/com/application/frontend/di/NetworkModule.kt
+++ b/frontend/app/src/main/java/com/application/frontend/di/NetworkModule.kt
@@ -13,7 +13,7 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
 
-    private const val BASE_URL = "https://your.api.endpoint/"
+    private const val BASE_URL = "http://10.0.2.2:8080/"
 
     @Provides
     @Singleton

--- a/frontend/app/src/main/java/com/application/frontend/ui/screen/CategoryScreen.kt
+++ b/frontend/app/src/main/java/com/application/frontend/ui/screen/CategoryScreen.kt
@@ -2,6 +2,7 @@ package com.application.frontend.ui.screen
 
 import android.content.res.Resources
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -28,7 +29,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -173,16 +176,16 @@ fun CategoryScreen(
                             modifier = Modifier.size(72.dp),
                             color = MaterialTheme.colorScheme.surfaceVariant
                         ) {
-                            Box(
-                                modifier = Modifier.fillMaxSize(),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Icon(
-                                    painter = painterResource(id = safeIconRes),
-                                    contentDescription = sub.name,
-                                    modifier = Modifier.size(40.dp)
-                                )
-                            }
+                            // 원 내부에 사진을 "그대로" 담기: 잘리지 않도록 Fit 사용
+                            Image(
+                                painter = painterResource(id = safeIconRes),
+                                contentDescription = sub.name,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    //.padding(12.dp)         // 가장자리 여백(원에 딱 맞추려면 줄이거나 제거)
+                                    .clip(CircleShape),     // 표면과 동일하게 원형으로 클립
+                                contentScale = ContentScale.Fit // 크기만 맞추고 크롭 없음
+                            )
                         }
                         Spacer(Modifier.height(8.dp))
                         Text(

--- a/frontend/app/src/main/java/com/application/frontend/viewmodel/CategoryViewModel.kt
+++ b/frontend/app/src/main/java/com/application/frontend/viewmodel/CategoryViewModel.kt
@@ -1,8 +1,10 @@
 package com.application.frontend.viewmodel
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.application.frontend.BuildConfig
 import com.application.frontend.R
 import com.application.frontend.data.CategoryApi
 import com.application.frontend.model.Category
@@ -15,12 +17,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+private const val TAG = "CategoryAPI"
 @HiltViewModel
 class CategoryViewModel @Inject constructor(
     private val api: CategoryApi,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
-
     // ① 상단에 표시할 메인 카테고리 리스트를 미리 정의
     val topCategories: List<Category> = listOf(
         Category(R.drawable.ic_pet,     "페트병"),
@@ -45,7 +47,8 @@ class CategoryViewModel @Inject constructor(
                 api.getSubCategories(categoryName)              // List<SubCategoryDto>
             }.onSuccess { remote: List<SubCategoryDto> ->
                 _subs.value = remote.map { it.toUi() }    // → List<Category(iconRes:Int, name:String)
-            }.onFailure {
+            }.onFailure { e ->
+                if (BuildConfig.DEBUG) Log.e(TAG, "loadSubs failed: $categoryName", e)
                 _subs.value = emptyList()   //실패 시 빈 리스트
             }
         }

--- a/src/main/java/com/greencoach/controller/CategoryController.kt
+++ b/src/main/java/com/greencoach/controller/CategoryController.kt
@@ -17,8 +17,8 @@ class CategoryController (
     fun fetchTopCategories(): List<CategoryDto> =
         categoryService.getTopCategories()
 
-    /** GET  /api/categories/{name}/subs */
-    @GetMapping("/{name}/subs")
+    /** GET  /api/categories/{name}/sub */
+    @GetMapping("/{name}/sub")
     fun fetchSubCategories(
         @PathVariable("name") name: String
     ): List<CategoryDto> =


### PR DESCRIPTION
## 📖 개요
카테고리 화면에서 서브카테고리가 비어 있는 문제를 해결했습니다.
- **백엔드**: 엔드포인트 경로 불일치 수정
- **프론트**: API 베이스 URL 교정, 로깅/아이콘 렌더링 개선

## 🔧 변경 파일
### Backend
- **CategoryController.kt**
  - 경로 정정: `GET /api/categories/{name}/subs` → `/api/categories/{name}/sub`
  - 프론트 CategoryApi와 경로 정합성 확보(404 발생 원인 제거)

### Frontend
- **NetworkModule.kt**
  - BASE_URL을 에뮬레이터용 `http://10.0.2.2:8080/`로 설정(로컬 서버 연결 고정)

- **CategoryViewModel.kt**
  - API 실패 시 로그 추가(디버그 빌드에서만 출력: `BuildConfig.DEBUG`)
  - 실패 시 빈 리스트 처리 유지(향후 Empty/에러 UI 연계 예정)

- **CategoryScreen.kt**
  - Icon → Image로 교체, tint 제거
  - 원형 컨테이너(72dp) 내부에 `ContentScale.Fit`로 PNG 원본 색상/비율 유지 렌더링

## 🧪 테스트 방법
1) 앱 실행 → Home에서 “페트병” 클릭 → CategoryScreen 진입
2) 우측 그리드에 “생수” 서브카테고리 아이콘이 원형 영역 내에 정상 표시되는지 확인
3) Logcat(디버그 빌드)에서 오류 로그가 더 이상 발생하지 않는지 확인

## ✅ 결과
- 서브카테고리 목록이 정상 로드되고, PNG 아이콘이 원본 색으로 동그라미 내부에 표시됩니다.

## 🗒️ 비고(후속)
- 서브카테고리 아이콘 다건 추가는 별도 PR로 진행 예정

## 📸 스크린샷
<img width="200" height="444" alt="Image" src="https://github.com/user-attachments/assets/fad2c33c-7373-4e54-bf0e-c61a3224b563" />