### PR TITLE
test(service): add CategoryService unit tests

### DIFF
--- a/src/test/java/com/greencoach/service/CategoryServiceTest.kt
+++ b/src/test/java/com/greencoach/service/CategoryServiceTest.kt
@@ -1,0 +1,50 @@
+package com.greencoach.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class CategoryServiceTest {
+
+    private val service = CategoryService()
+
+    @Nested
+    @DisplayName("getTopCategories")
+    inner class GetTopCategories {
+
+        @Test
+        fun `최상위 카테고리 목록을 반환한다`() {
+            val result = service.getTopCategories()
+
+            assertThat(result).isNotEmpty
+            // 대표 항목 몇 개만 검증(전체 리스트에 과도하게 결합하지 않기)
+            assertThat(result.map { it.name })
+                .contains("페트병", "플라스틱 용기", "캔류")
+            // 아이콘 경로 형태 검증
+            assertThat(result.all { it.imageUrl.startsWith("/images/icons/") }).isTrue
+        }
+    }
+
+    @Nested
+    @DisplayName("getSubCategories")
+    inner class GetSubCategories {
+
+        @Test
+        fun `존재하는 상위 카테고리(페트병)면 서브 카테고리를 반환한다`() {
+            val result = service.getSubCategories("페트병")
+
+            assertThat(result).isNotEmpty
+            // "생수"가 있고 지정된 이미지가 매핑되는지
+            assertThat(result.any { it.name == "생수" && it.imageUrl.endsWith("/images/sub/pet_water.png") })
+                .isTrue
+        }
+
+        @Test
+        fun `없는 상위 카테고리면 빈 리스트를 반환한다`() {
+            val result = service.getSubCategories("없는카테고리")
+
+            assertThat(result).isEmpty()
+        }
+    }
+}


### PR DESCRIPTION
## 📖 개요
- `CategoryService`에 대한 단위 테스트를 추가했습니다.  
- JUnit 5 + AssertJ 사용, Spring 컨텍스트 미기동(순수 단위 테스트).

## 🔧 변경 사항
- `CategoryServiceTest.kt` 신규 추가
  - `getTopCategories()`  
    - 반환 리스트가 비어있지 않은지 검증  
    - 대표 카테고리명 포함 여부 검증(예: "페트병", "플라스틱 용기", "캔류")  
    - `imageUrl` 형식이 `/images/icons/` 프리픽스를 따르는지 검증
  - `getSubCategories("페트병")`  
    - "생수" 항목 존재 및 `imageUrl`이 `/images/sub/pet_water.png`로 끝나는지 검증
  - `getSubCategories("없는카테고리")`  
    - 빈 리스트 반환 검증