### PR TITLE
test(service): add unit test for SubCategoryDetailService

### DIFF
--- a/src/test/java/com/greencoach/service/SubCategoryDetailServiceTest.kt
+++ b/src/test/java/com/greencoach/service/SubCategoryDetailServiceTest.kt
@@ -1,0 +1,37 @@
+package com.greencoach.service
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+
+class SubCategoryDetailServiceTest {
+    private val service = SubCategoryDetailService()
+
+    @Test
+    fun `getDetail returns dto for pet_water with expected fields`() {
+        val dto = service.getDetail("pet_water")
+        assertNotNull(dto, "pet_water 키에 대해 null이 반환되면 안 됩니다.")
+        dto!!
+
+        // 기본 필드
+        assertEquals("pet_water", dto.key)
+        assertEquals("생수", dto.name)
+        assertEquals("/images/sub/pet_water.png", dto.imageUrl)
+        assertEquals("#66CBD2", dto.headerColor)
+        assertTrue(dto.subtitle.isNotBlank(), "subtitle은 비어있지 않아야 합니다.")
+
+        // 단계(steps)
+        assertEquals(2, dto.steps.size, "단계 섹션 수가 일치하지 않습니다.")
+        assertEquals("내용물 비우기", dto.steps[0].title)
+        assertTrue(dto.steps[0].bullets.isNotEmpty(), "첫 번째 단계 bullets가 비어있습니다.")
+        assertEquals("라벨 제거", dto.steps[1].title)
+
+        // 잘못된 배출 예시
+        assertEquals(3, dto.wrongExamples.size, "잘못된 배출 예시 개수가 일치하지 않습니다.")
+    }
+
+    @Test
+    fun `getDetail returns null for unknown key`() {
+        val dto = service.getDetail("unknown_key")
+        assertNull(dto, "알 수 없는 키에 대해서는 null이 반환되어야 합니다.")
+    }
+}


### PR DESCRIPTION
## 📖 개요
서브카테고리 상세 정보를 반환하는 `SubCategoryDetailService`에 대한 단위 테스트를 작성했습니다.  
정상적인 key에 대한 응답 구조를 검증하고, 존재하지 않는 key에 대한 처리도 포함되어 있습니다.

## 🔧 변경사항
- `SubCategoryDetailServiceTest.kt` 추가
  - `"pet_water"` key에 대한 응답 필드(key, name, imageUrl, headerColor, subtitle 등) 값 검증
  - 단계(`steps`)와 잘못된 배출 예시(`wrongExamples`) 항목 개수 및 내용 검증
  - 존재하지 않는 key에 대해 `null`을 반환하는지 검증

## 🧪 테스트 방법
1. 테스트 파일 위치: `src/test/kotlin/com/greencoach/service/SubCategoryDetailServiceTest.kt`
2. 테스트 실행: `./gradlew test` 또는 IDE에서 직접 실행
3. 모든 테스트가 성공적으로 통과하는지 확인

## ✅ 결과
- `SubCategoryDetailService`의 응답 구조와 필드 값이 의도대로 구성되어 있는지 확인됨
- 예상하지 못한 key 입력에 대해서는 `null`을 반환하도록 안전하게 처리됨
