### PR TITLE
[Scan Backend &AI] integrate ONNX garbage classifier with Scan API and configuration profiles

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ configurations {
 
 repositories {
 	mavenCentral()
+    google()
 }
 
 dependencies {
@@ -37,6 +38,12 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("io.jsonwebtoken:jjwt-api:0.11.5")
 	implementation("org.springframework.boot:spring-boot-starter-mail") // (이메일 실제 전송 시)
+    // --- AI Runtime ---
+    implementation("com.microsoft.onnxruntime:onnxruntime:1.20.0")   // ONNX Runtime
+    implementation("org.tensorflow:tensorflow-lite:2.12.0")
+    implementation("org.tensorflow:tensorflow-lite-api:2.12.0")// TensorFlow Lite
+    implementation("org.tensorflow:tensorflow-lite-support:0.5.0")
+
 
 	compileOnly("org.projectlombok:lombok")
 

--- a/frontend/gradle/libs.versions.toml
+++ b/frontend/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.11.1"
+agp = "8.13.0"
 kotlin = "2.0.21"
 coreKtx = "1.16.0"
 junit = "4.13.2"

--- a/src/main/java/com/greencoach/config/SecurityConfig.kt
+++ b/src/main/java/com/greencoach/config/SecurityConfig.kt
@@ -37,16 +37,21 @@ class SecurityConfig(
                     "/auth/**",
                     "/actuator/health"
                 ).permitAll()
-                    .requestMatchers(org.springframework.http.HttpMethod.GET,
-                        "/api/news/**",
-                        "/api/co2/**",
-                        "/api/categories/**",
-                        "/api/subcategories/**",
-                        "/images/**"            // (정적 이미지 사용 시)
-                    ).permitAll()
-                    .anyRequest().authenticated()
-            }
+                // ✅ 스캔 업로드는 인증 없이 허용 (모든 HTTP 메서드)
+                it.requestMatchers("/api/scan/**").permitAll()
 
+                // GET 공개 엔드포인트들
+                it.requestMatchers(
+                    org.springframework.http.HttpMethod.GET,
+                    "/api/news/**",
+                    "/api/co2/**",
+                    "/api/categories/**",
+                    "/api/subcategories/**",
+                    "/images/**"
+                ).permitAll()
+
+                it.anyRequest().authenticated()
+            }
             .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter::class.java)
         return http.build()
     }

--- a/src/main/java/com/greencoach/controller/ScanController.kt
+++ b/src/main/java/com/greencoach/controller/ScanController.kt
@@ -1,0 +1,19 @@
+package com.greencoach.controller
+
+import com.greencoach.model.scan.ScanResponse
+import com.greencoach.service.ScanService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@RequestMapping("/api/scan")
+class ScanController(
+    private val scanService: ScanService
+) {
+    @PostMapping(consumes = ["multipart/form-data"])
+    fun scan(@RequestParam("file") file: MultipartFile): ResponseEntity<ScanResponse> {
+        val result = scanService.analyzeImage(file)
+        return ResponseEntity.ok(result)
+    }
+}

--- a/src/main/java/com/greencoach/model/scan/ScanDtos.kt
+++ b/src/main/java/com/greencoach/model/scan/ScanDtos.kt
@@ -1,0 +1,31 @@
+package com.greencoach.model.scan
+
+import java.time.Instant
+import jakarta.validation.constraints.NotBlank
+
+/**
+ * 업로드와 함께 올 수 있는 간단한 메타 정보 (필요 없으면 사용 안 해도 됨)
+ */
+data class ScanMetadata(
+    val userId: String? = null,
+    val notes: String? = null
+)
+
+/**
+ * AI가 반환한 단일 예측 결과
+ */
+data class Prediction(
+    @field:NotBlank
+    val label: String,
+    val confidence: Double,
+    val category: String? = null
+)
+
+/**
+ * 최종 응답: 예측 리스트 + 처리 정보
+ */
+data class ScanResponse(
+    val items: List<Prediction>,
+    val model: String,
+    val processedAt: Instant = Instant.now()
+)

--- a/src/main/java/com/greencoach/service/ScanService.kt
+++ b/src/main/java/com/greencoach/service/ScanService.kt
@@ -1,0 +1,19 @@
+package com.greencoach.service
+
+import com.greencoach.model.scan.ScanResponse
+import com.greencoach.service.ai.AiEngine
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+
+@Service
+class ScanService(
+    private val aiEngine: AiEngine
+) {
+    fun analyzeImage(file: MultipartFile): ScanResponse {
+        val predictions = aiEngine.predict(file)
+        return ScanResponse(
+            items = predictions,
+            model = aiEngine.modelName
+        )
+    }
+}

--- a/src/main/java/com/greencoach/service/ai/AiEngine.kt
+++ b/src/main/java/com/greencoach/service/ai/AiEngine.kt
@@ -1,0 +1,16 @@
+package com.greencoach.service.ai
+
+import com.greencoach.model.scan.Prediction
+import org.springframework.web.multipart.MultipartFile
+
+/**
+ * 모든 AI 엔진이 따라야 하는 공통 인터페이스
+ */
+interface AiEngine {
+    val modelName: String
+
+    /**
+     * 이미지 파일을 받아서 예측 결과 반환
+     */
+    fun predict(file: MultipartFile): List<Prediction>
+}

--- a/src/main/java/com/greencoach/service/ai/LabelLoader.kt
+++ b/src/main/java/com/greencoach/service/ai/LabelLoader.kt
@@ -1,0 +1,13 @@
+package com.greencoach.service.ai
+
+import java.io.InputStreamReader
+
+object LabelLoader {
+    fun loadLabels(resourcePath: String = "/models/classes.txt"): List<String> {
+        val stream = javaClass.getResourceAsStream(resourcePath)
+            ?: throw IllegalStateException("Labels not found: $resourcePath")
+        return InputStreamReader(stream).readLines()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+    }
+}

--- a/src/main/java/com/greencoach/service/ai/OnnxAiEngine.kt
+++ b/src/main/java/com/greencoach/service/ai/OnnxAiEngine.kt
@@ -1,0 +1,111 @@
+package com.greencoach.service.ai
+
+import com.greencoach.model.scan.Prediction
+import ai.onnxruntime.*
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+import org.springframework.web.multipart.MultipartFile
+import java.awt.Color
+import java.awt.Image
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.nio.FloatBuffer
+import jakarta.annotation.PreDestroy
+import javax.imageio.ImageIO
+import kotlin.math.exp
+
+@Component
+@Profile("onnx")
+class OnnxAiEngine : AiEngine {
+
+    override val modelName: String = "onnx-garbage-classifier"
+
+    private val inputSize = 224
+    private val channels = 3
+    private val normalize = 1.0f / 255.0f
+
+    private val env: OrtEnvironment = OrtEnvironment.getEnvironment()
+    private val session: OrtSession
+    private val inputName: String
+    private val labels: List<String> = LabelLoader.loadLabels("/models/classes.txt")
+
+    init {
+        val bytes = javaClass.getResourceAsStream("/models/garbage_classifier.onnx")
+            ?.readAllBytes() ?: throw IllegalStateException("ONNX model not found in /models")
+
+        session = env.createSession(bytes)          // ✅ 세션 생성 (한 번만)
+        inputName = session.inputNames.first()      // ✅ 입력 이름 캐싱
+    }
+
+    override fun predict(file: MultipartFile): List<Prediction> {
+        val tensor = preprocessToNCHWFloat(file.bytes, inputSize, inputSize) // [1,3,224,224]
+
+        // ✅ 세션은 닫지 않는다!
+        val results = session.run(mapOf(inputName to tensor))
+        results.use {
+            @Suppress("UNCHECKED_CAST")
+            val raw = it[0].value as Array<FloatArray> // [1, numClasses]
+            val probs = softmax(raw[0])
+            return probs.mapIndexed { i, p ->
+                Prediction(
+                    label = labels.getOrElse(i) { "class_$i" },
+                    confidence = p.toDouble(),
+                    category = null
+                )
+            }.sortedByDescending { it.confidence }
+        }
+    }
+
+    /** 이미지 → resize(224x224) → NCHW float32 [1,3,H,W] */
+    private fun preprocessToNCHWFloat(imageBytes: ByteArray, w: Int, h: Int): OnnxTensor {
+        val img = ImageIO.read(ByteArrayInputStream(imageBytes))
+            ?: throw IllegalArgumentException("Invalid image file")
+        val resized = resize(img, w, h)
+
+        val buffer = FloatArray(1 * channels * h * w)
+        var idx = 0
+        // R
+        for (y in 0 until h) for (x in 0 until w) {
+            val c = Color(resized.getRGB(x, y))
+            buffer[idx++] = c.red * normalize
+        }
+        // G
+        for (y in 0 until h) for (x in 0 until w) {
+            val c = Color(resized.getRGB(x, y))
+            buffer[idx++] = c.green * normalize
+        }
+        // B
+        for (y in 0 until h) for (x in 0 until w) {
+            val c = Color(resized.getRGB(x, y))
+            buffer[idx++] = c.blue * normalize
+        }
+
+        val shape = longArrayOf(1, channels.toLong(), h.toLong(), w.toLong())
+        return OnnxTensor.createTensor(env, FloatBuffer.wrap(buffer), shape)
+    }
+
+    private fun resize(src: BufferedImage, w: Int, h: Int): BufferedImage {
+        val scaled: Image = src.getScaledInstance(w, h, Image.SCALE_SMOOTH)
+        val dst = BufferedImage(w, h, BufferedImage.TYPE_INT_RGB)
+        val g = dst.createGraphics()
+        g.drawImage(scaled, 0, 0, null)
+        g.dispose()
+        return dst
+    }
+
+    private fun softmax(logits: FloatArray): FloatArray {
+        val max = logits.maxOrNull() ?: 0f
+        var sum = 0.0
+        val exps = DoubleArray(logits.size) { i ->
+            val e = exp((logits[i] - max).toDouble()); sum += e; e
+        }
+        return FloatArray(logits.size) { i -> (exps[i] / sum).toFloat() }
+    }
+
+    @PreDestroy
+    fun close() {
+        // ✅ 애플리케이션 종료 시에만 정리
+        try { session.close() } catch (_: Exception) {}
+        try { env.close() } catch (_: Exception) {}
+    }
+}

--- a/src/main/resources/application-onnx.yml
+++ b/src/main/resources/application-onnx.yml
@@ -1,0 +1,4 @@
+naver:
+  client:
+    id: QfqGUbdLTZMXCru2Gf7W
+    secret: P31kDv2n_Q

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: greencoach
   profiles:
-    active: local
+    active: onnx   # 또는 tflite
   codec:
     max-in-memory-size: 20MB
   datasource:

--- a/src/main/resources/models/classes.txt
+++ b/src/main/resources/models/classes.txt
@@ -1,0 +1,13 @@
+glass
+paper
+plastic
+pet
+can
+styrofoam
+clothesTextiles
+BigAppliances
+vinyl
+scrapMetal
+SmallAppliances
+Battery
+Furniture


### PR DESCRIPTION
## 📖 개요

- ONNX 모델을 백엔드 Spring Boot 애플리케이션에 연동했습니다.

- OnnxAiEngine을 추가하여 이미지 업로드 시 분류 결과를 반환합니다.

- application-onnx.yml을 신설해 ONNX 실행 전용 설정을 분리했습니다.

- SecurityConfig를 업데이트해 /api/scan 엔드포인트를 JWT 기반 인증 흐름에 통합했습니다.

## 🔧 변경사항
### Backend

-  **AI Engine**

   - `OnnxAiEngine.kt`  : ONNX 모델 로딩 및 추론 처리

   - `AiEngine.kt` : AI 엔진 인터페이스 정의

   - `LabelLoader.kt` : 클래스 라벨 로딩 유틸

   - `classes.txt` / `garbage_classifier.onnx` : 모델 리소스 추가

- **서비스/컨트롤러**

   - `ScanService.kt` : 업로드된 이미지를 ONNX 엔진에 전달, 결과 반환

   - `ScanController.kt` : /api/scan 엔드포인트 추가 (multipart 업로드 지원)

   - `ScanDtos.kt` : 결과 응답 DTO 정의

- **보안**

   - `SecurityConfig.kt` : /api/scan 엔드포인트 인증 적용

- **환경설정**

   - `application.yml` : 기본 설정

   - `application-onnx.yml` : ONNX 전용 실행 프로필 추가

- **빌드**

   - `build.gradle.kts` : onnxruntime 1.20.0 의존성 추가

## 🧪 테스트 방법

1. 서버 실행: 터미널에 작성.

<img width="636" height="78" alt="스크린샷 2025-09-24 223547" src="https://github.com/user-attachments/assets/c7973ef1-9817-4150-a883-dd3b039e7309" />

2. Postman에서 POST 호출 방식이 GET이 아닌 POST로 변경

3. Postman에서 POST http://localhost:8080/api/scan 호출

4. Body → form-data → file (Key값), value에 이미지 업로드

5. 응답에 label 과 confidence 값이 포함되는지 확인

6. confidence가 가장 높은 label이 분류 결과로 간주됨

## 🗒️ 비고

- 현재는 H2 인메모리 DB 환경에서 실행됨.

- 추후 Forest 화면과 연동 시, 누적 scan 결과를 상태로 전달할 예정.